### PR TITLE
Fixed "duplicate" word

### DIFF
--- a/architecture/index.html
+++ b/architecture/index.html
@@ -1817,7 +1817,7 @@ input.onkeyup = function () {
         <a href="https://tools.ietf.org/html/rfc4287">Atom</a>.
       </li>
       <li class="next opinion">
-        Social media streams pushed seem to<br>
+        Social media streams seem to<br>
         have pushed feeds to the background.
       </li>
     </ul>


### PR DESCRIPTION
It didn't make much sense with the extra pushed there
