### PR TITLE
Fix typos

### DIFF
--- a/linked-data-publishing/index.html
+++ b/linked-data-publishing/index.html
@@ -1813,7 +1813,7 @@
     <ul>
       <li class="next">
         Continuously improve Linked Data<br>
-        though efficient iterations of the cycle.
+        through efficient iterations of the cycle.
       </li>
       <li class="next opinion">
         If we want to see intelligent agents,<br>

--- a/semantic-web/index.html
+++ b/semantic-web/index.html
@@ -2052,7 +2052,7 @@ foaf:knows rdfs:domain foaf:Person.</code></pre>
       <li>
         Load the data <em>together</em> with its vocabularies.
         <ul>
-          <li>RDFS reasoning is built-in, but not your vocabulary.</li>
+          <li>OWL reasoning is built-in, but not your vocabulary.</li>
         </ul>
       </li>
     </ul>

--- a/web-apis/index.html
+++ b/web-apis/index.html
@@ -854,7 +854,7 @@
         An HTTP URL points to at most one resource.
         <ul>
           <li>The URL <a href="../architecture/#identification-location">identifies</a> the resource.</li>
-          <li>If it is an in <a href="#resources">information resource</a>,<br>
+          <li>If it is an <a href="#resources">information resource</a>,<br>
               HTTP allows clients to retrieve a representation of it.</li>
         </ul>
       </li>


### PR DESCRIPTION
- Fixes some small typos in the Web API and Linked Data sections.
- In the Semantic Web section, the slide about OWL reasoners said: `RDFS reasoning is built-in`, but this should probably be `OWL reasoning is built-in`, although OWL extends RDFS so I guess it would still contain RDFS reasoning so I'm not sure about the correctness of this change.