### PR TITLE
hide nav on print

### DIFF
--- a/_shared/styles/web-fundamentals.css
+++ b/_shared/styles/web-fundamentals.css
@@ -436,3 +436,8 @@ ol.query code {
   letter-spacing: -1px;
   white-space: nowrap;
 }
+@media print {
+  nav{
+    display: none;
+  }
+}


### PR DESCRIPTION
While printing I noticed that the nav on the side didn't hide, so it caused some small overlap on some slides.

I added some CSS which solved the problem for me.
