### PR TITLE
Fixed typo in "self-descriptive messaging"-slide

### DIFF
--- a/web-apis/index.html
+++ b/web-apis/index.html
@@ -583,7 +583,7 @@
       <li class="next">
         Intermediaries can interpret messages.
         <ol>
-          <li><a href="#stateless">statelessness</a> and explicit <a href="#cache">cacheablity</a></li>
+          <li><a href="#stateless">statelessness</a> and explicit <a href="#cache">cacheability</a></li>
           <li>limited number of <em>standardized operations</em></li>
         </ol>
       </li>


### PR DESCRIPTION
The word "cacheability" contained a typo.