### PR TITLE
Inconsistentie in de voorbeelden weggewerkt

### DIFF
--- a/architecture/index.html
+++ b/architecture/index.html
@@ -254,7 +254,7 @@
       The uniform structure of an HTTP URL<br>
       includes the following parts.
     </h2>
-    <p><code>https://&lt;host&gt;/&lt;path&gt;?&lt;search&gt;#&lt;fragment&gt;</code></p>
+    <p><code>http://&lt;host&gt;/&lt;path&gt;?&lt;search&gt;#&lt;fragment&gt;</code></p>
     <dl>
       <dt>hostname</dt>
       <dd>identifies the machine</dd>
@@ -290,7 +290,7 @@
       An HTTP URL provides the instructions<br>
       to obtain a representation of the resource.
     </h2>
-    <p><code>https://&lt;host&gt;/&lt;path&gt;?&lt;search&gt;#&lt;fragment&gt;</code></p>
+    <p><code>http://&lt;host&gt;/&lt;path&gt;?&lt;search&gt;#&lt;fragment&gt;</code></p>
     <ol>
       <li class="next">
         The client looks up the host’s IP address.


### PR DESCRIPTION
Inconsistent gebruik van https en http in de voorbeelden op dia's #url-parts, #url-parts-example, #url-instructions en #url-instructions-example weggewerkt