### PR TITLE
[Architecture] Fix anchor tags pointing to non-existent resource

### DIFF
--- a/architecture/index.html
+++ b/architecture/index.html
@@ -1240,8 +1240,8 @@ Last-Modified: Sun, 24 Jan 2016 18:26:27 GMT</span>
             languages:
             <ul class="inline">
               <li>Java</li>
-              <li><a href="#php">PHP</a></li>
-              <li><a href="#javascript">JavaScript</a></li>
+              <li>PHP</li>
+              <li>JavaScript</li>
               <li>Ruby</li>
               <li>C#</li>
               <li>…</li>
@@ -1253,8 +1253,8 @@ Last-Modified: Sun, 24 Jan 2016 18:26:27 GMT</span>
             frameworks:
             <ul class="inline">
               <li>Spring MVC</li>
-              <li><a href="#ruby-on-rails">Ruby on Rails</a></li>
-              <li><a href="#aspnet">ASP.NET</a></li>
+              <li>Ruby on Rails</li>
+              <li>ASP.NET</li>
               <li>…</li>
             </ul>
           </li>


### PR DESCRIPTION
These ``<a>`` tags in the slide seem to point to something that no longer exists, so I removed them as they are a bit misleading.

Relevant slide for reference: https://rubenverborgh.github.io/WebFundamentals/architecture/#application-server