### PR TITLE
Websites can have multiple ip addresses

### DIFF
--- a/architecture/index.html
+++ b/architecture/index.html
@@ -290,7 +290,7 @@
     <p><code>http://&lt;host&gt;/&lt;path&gt;?&lt;search&gt;#&lt;fragment&gt;</code></p>
     <ol>
       <li class="next">
-        The client looks up the host’s IP address.
+        The client looks up one of the host’s IP addresses.
         <ul>
           <li>The client uses DNS for this.</li>
         </ul>

--- a/semantic-web/index.html
+++ b/semantic-web/index.html
@@ -1126,8 +1126,8 @@ dbr:Tim_Berners-Lee schema:givenName "Tim";
       <li class="next">
         RDFS defines concepts in two namespaces.
         <ul>
-          <li><code>rdf</code>: <a href="https://www.w3.org/1999/02/22-rdf-syntax-ns#"><em>https://www.w3.org/1999/02/22-rdf-syntax-ns#</em></a></li>
-          <li><code>rdfs</code>: <a href="https://www.w3.org/2000/01/rdf-schema#"><em>https://www.w3.org/2000/01/rdf-schema#</em></a></li>
+          <li><code>rdf</code>: <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><em>http://www.w3.org/1999/02/22-rdf-syntax-ns#</em></a></li>
+          <li><code>rdfs</code>: <a href="http://www.w3.org/2000/01/rdf-schema#"><em>http://www.w3.org/2000/01/rdf-schema#</em></a></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
Niet enkel wikipedia (#97) kan meer dan 1 ip adres hebben, dus dit moet ook voor het algemene geval worden gewijzigd.
RDF en RDFS worden via een HTTP url geïdentificeerd.