### PR TITLE
Fixed three broken URLs

### DIFF
--- a/architecture/index.html
+++ b/architecture/index.html
@@ -1710,17 +1710,17 @@ remoteObject.deleteMessage(234);</code></pre>
     </h2>
     <ul>
       <li class="next">
-        <a href="https://http2-explained.haxx.se/content/en/part2.html#23-inadequate-use-of-tcp">TCP connections are not used optimally.</a>
+        <a href="https://http2-explained.haxx.se/en/part2#id-2.3-inadequate-use-of-tcp">TCP connections are not used optimally.</a>
         <ul>
           <li>Connections are costly due to the three-way handshake.</li>
           <li>Limit the connections per host to avoid exhaustion.</li>
         </ul>
       </li>
       <li class="next">
-        <a href="https://http2-explained.haxx.se/content/en/part2.html#25-latency-kills">HTTP is very latency-sensitive.</a>
+        <a href="https://http2-explained.haxx.se/en/part2#id-2.5-latency-kills">HTTP is very latency-sensitive.</a>
       </li>
       <li class="next">
-        <a href="https://http2-explained.haxx.se/content/en/part2.html#26-head-of-line-blocking">Sequential handling of requests blocks pipelines.</a>
+        <a href="https://http2-explained.haxx.se/en/part2#id-2.6.-head-of-line-blocking">Sequential handling of requests blocks pipelines.</a>
         <ul>
           <li>
             <em>HTTP pipelining</em> allows issuing multiple requests on a single TCP connection


### PR DESCRIPTION
Fixed three incorrect (404) URLs on slide ['Several limitations of HTTP have a negative impact on page load times.'](https://rubenverborgh.github.io/WebFundamentals/architecture/#http-limitations)